### PR TITLE
Add support for returning summarized node status

### DIFF
--- a/fetch-validator-status/README.md
+++ b/fetch-validator-status/README.md
@@ -59,10 +59,28 @@ cd indy-node-monitor/fetch-validator-status
 
 ### Run the Validator Info Script
 
+For a full list of script options run:
+``` bash
+./run.sh -h
+```
+
 To run the validator script, run the following command in your bash terminal from the `fetch-validator-status` folder in the `indy-node-monitor` clone:
 
 ``` bash
 GENESIS_URL=<URL> SEED=<SEED> ./run.sh
+```
+or 
+``` bash
+./run.sh --genesis-url=<URL> --seed=<SEED> 
+```
+
+To just get a status summary for the nodes, run:
+``` bash
+GENESIS_URL=<URL> SEED=<SEED> ./run.sh --status
+```
+or 
+``` bash
+./run.sh --genesis-url=<URL> --seed=<SEED> --status
 ```
 
 For the first test run using von-network:
@@ -75,11 +93,20 @@ If you are running locally, the full command is:
 ``` bash
 GENESIS_URL=http://localhost:9000/genesis SEED=000000000000000000000000Trustee1 ./run.sh
 ```
+or 
+``` bash
+./run.sh --genesis-url=http://localhost:9000/genesis --seed=000000000000000000000000Trustee1
+```
+
 
 To perform an anonymous connection test when a privileged DID seed is not available, omit the `SEED` and pass the `-a` parameter:
 
 ``` bash
 GENESIS_URL=<URL> ./run.sh -a
+```
+or
+``` bash
+./run.sh --genesis-url=<URL> -a
 ```
 
 If running in the browser, you will have to get the URL for the Genesis file (as described above) and replace the `localhost` URL above.

--- a/fetch-validator-status/README.md
+++ b/fetch-validator-status/README.md
@@ -83,6 +83,11 @@ or
 ./run.sh --genesis-url=<URL> --seed=<SEED> --status
 ```
 
+To fetch data for a single node, or a particular set of nodes use the `--nodes` argument and provide a comma delimited list of node names (aliases);
+``` bash
+./run.sh --genesis-url=<URL> --seed=<SEED> --status --nodes node1,node2
+```
+
 For the first test run using von-network:
 
 - the `<SEED>` is the Indy test network Trustee seed: `000000000000000000000000Trustee1`.

--- a/fetch-validator-status/fetch_status.py
+++ b/fetch-validator-status/fetch_status.py
@@ -104,7 +104,7 @@ async def get_primary_name(jsval: any, node: str) -> str:
 async def get_status_summary(jsval: any, errors: list) -> any:
     status = {}
     status["ok"] = (len(errors) <= 0)
-    if jsval:
+    if jsval and ("REPLY" in jsval["op"]):
         if "Node_info" in jsval["result"]["data"]:
             status["uptime"] = str(datetime.timedelta(seconds = jsval["result"]["data"]["Node_info"]["Metrics"]["uptime"]))
         if "timestamp" in jsval["result"]["data"]:
@@ -161,9 +161,9 @@ async def detect_issues(jsval: any, node: str, primary: str, ident: DidKey = Non
                 warnings.append("Denylisted Nodes: {1}".format(jsval["result"]["data"]["Pool_info"]["Blacklisted_nodes"]))
     else:
         if "reason" in jsval:
-            errors = jsval["reason"]
+            errors.append(jsval["reason"])
         else:
-            errors = "unknown error"
+            errors.append("unknown error")
 
     return errors, warnings
 

--- a/fetch-validator-status/fetch_status.py
+++ b/fetch-validator-status/fetch_status.py
@@ -48,7 +48,7 @@ def seed_as_bytes(seed):
     return seed.encode("ascii")
 
 
-async def fetch_status(genesis_path: str, ident: DidKey = None, status_only: bool = False):
+async def fetch_status(genesis_path: str, nodes: str = None, ident: DidKey = None, status_only: bool = False):
     pool = await open_pool(transactions_path=genesis_path)
     result = []
 
@@ -58,7 +58,10 @@ async def fetch_status(genesis_path: str, ident: DidKey = None, status_only: boo
     else:
         request = build_get_txn_request(None, 1, 1)
 
-    response = await pool.submit_action(request)
+    from_nodes = []
+    if nodes:
+        from_nodes = nodes.split(",")
+    response = await pool.submit_action(request, node_aliases = from_nodes)
 
     primary = ""
     for node, val in response.items():
@@ -185,6 +188,7 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--seed", default=os.environ.get('SEED') , help="The privileged DID seed to use for the ledger requests.  Can be specified using the 'SEED' environment variable.")
     parser.add_argument("-a", "--anonymous", action="store_true", help="Perform requests anonymously, without requiring privileged DID seed.")
     parser.add_argument("--status", action="store_true", help="Get status only.  Suppresses detailed results.")
+    parser.add_argument("--nodes", help="The comma delimited list of the nodes from which to collect the status.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging.")
     args = parser.parse_args()
 
@@ -210,4 +214,4 @@ if __name__ == "__main__":
     else:
         ident = None
 
-    asyncio.get_event_loop().run_until_complete(fetch_status(args.genesis_path, ident, args.status))
+    asyncio.get_event_loop().run_until_complete(fetch_status(args.genesis_path, args.nodes, ident, args.status))

--- a/fetch-validator-status/fetch_status.py
+++ b/fetch-validator-status/fetch_status.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--seed", default=os.environ.get('SEED') , help="The privileged DID seed to use for the ledger requests.  Can be specified using the 'SEED' environment variable.")
     parser.add_argument("-a", "--anonymous", action="store_true", help="Perform requests anonymously, without requiring privileged DID seed.")
     parser.add_argument("--status", action="store_true", help="Get status only.  Suppresses detailed results.")
-    parser.add_argument("--nodes", help="The comma delimited list of the nodes from which to collect the status.")
+    parser.add_argument("--nodes", help="The comma delimited list of the nodes from which to collect the status.  The default is all of the nodes in the pool.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging.")
     args = parser.parse_args()
 

--- a/fetch-validator-status/fetch_status.py
+++ b/fetch-validator-status/fetch_status.py
@@ -20,9 +20,12 @@ from indy_vdr.ledger import (
 from indy_vdr.pool import open_pool
 
 
-def log(*args):
-    print(*args, "\n", file=sys.stderr)
+verbose = False
 
+
+def log(*args):
+    if verbose:
+        print(*args, "\n", file=sys.stderr)
 
 class DidKey:
     def __init__(self, seed):
@@ -182,18 +185,21 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--seed", default=os.environ.get('SEED') , help="The privileged DID seed to use for the ledger requests.  Can be specified using the 'SEED' environment variable.")
     parser.add_argument("-a", "--anonymous", action="store_true", help="Perform requests anonymously, without requiring privileged DID seed.")
     parser.add_argument("--status", action="store_true", help="Get status only.  Suppresses detailed results.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging.")
     args = parser.parse_args()
+
+    verbose = args.verbose
 
     if args.genesis_url:
         download_genesis_file(args.genesis_url, args.genesis_path)
     if not os.path.exists(args.genesis_path):
-        log("Set the GENESIS_URL or GENESIS_PATH environment variable or argument.")
+        print("Set the GENESIS_URL or GENESIS_PATH environment variable or argument.\n", file=sys.stderr)
         parser.print_help()
         exit()
 
     did_seed = None if args.anonymous else args.seed
     if not did_seed and not args.anonymous:
-        log("Set the SEED environment variable or argument.")
+        print("Set the SEED environment variable or argument.\n", file=sys.stderr)
         parser.print_help()
         exit()
 


### PR DESCRIPTION
- Specifying the `--status` flag excludes the detailed (full) results of `get-validator-info`.
- Adds some additional details to the status section.
- Additional warnings
  - Denylisted Nodes
  - Mode, when not `participating`
  - Ledger Sync Status and transaction counts when the ledgers are not synced

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>