### PR TITLE
Add support for connecting to a ledger using a short network Id

### DIFF
--- a/fetch-validator-status/Dockerfile
+++ b/fetch-validator-status/Dockerfile
@@ -3,5 +3,6 @@ FROM bcgovimages/von-image:next-1
 RUN pip install pynacl
 
 ADD fetch_status.py .
+ADD networks.json .
 
 ENTRYPOINT ["bash", "-c", "python fetch_status.py $@", "--"]

--- a/fetch-validator-status/README.md
+++ b/fetch-validator-status/README.md
@@ -67,25 +67,25 @@ For a full list of script options run:
 To run the validator script, run the following command in your bash terminal from the `fetch-validator-status` folder in the `indy-node-monitor` clone:
 
 ``` bash
-GENESIS_URL=<URL> SEED=<SEED> ./run.sh
+./run.sh --net=<netId> --seed=<SEED>
 ```
-or 
+or
 ``` bash
-./run.sh --genesis-url=<URL> --seed=<SEED> 
+./run.sh --genesis-url=<URL> --seed=<SEED>
 ```
 
 To just get a status summary for the nodes, run:
 ``` bash
-GENESIS_URL=<URL> SEED=<SEED> ./run.sh --status
+./run.sh --net=<netId> --seed=<SEED> --status
 ```
-or 
+or
 ``` bash
 ./run.sh --genesis-url=<URL> --seed=<SEED> --status
 ```
 
 To fetch data for a single node, or a particular set of nodes use the `--nodes` argument and provide a comma delimited list of node names (aliases);
 ``` bash
-./run.sh --genesis-url=<URL> --seed=<SEED> --status --nodes node1,node2
+./run.sh --net=<netId> --seed=<SEED> --status --nodes node1,node2
 ```
 
 For the first test run using von-network:
@@ -96,9 +96,9 @@ For the first test run using von-network:
 If you are running locally, the full command is:
 
 ``` bash
-GENESIS_URL=http://localhost:9000/genesis SEED=000000000000000000000000Trustee1 ./run.sh
+./run.sh --net=vn --seed=000000000000000000000000Trustee1
 ```
-or 
+or
 ``` bash
 ./run.sh --genesis-url=http://localhost:9000/genesis --seed=000000000000000000000000Trustee1
 ```
@@ -107,7 +107,7 @@ or
 To perform an anonymous connection test when a privileged DID seed is not available, omit the `SEED` and pass the `-a` parameter:
 
 ``` bash
-GENESIS_URL=<URL> ./run.sh -a
+./run.sh --net=<netId> -a
 ```
 or
 ``` bash

--- a/fetch-validator-status/README.md
+++ b/fetch-validator-status/README.md
@@ -64,6 +64,11 @@ For a full list of script options run:
 ./run.sh -h
 ```
 
+To get the details for the known networks available for use with the `--net` option, run:
+``` bash
+./run.sh --list-nets
+```
+
 To run the validator script, run the following command in your bash terminal from the `fetch-validator-status` folder in the `indy-node-monitor` clone:
 
 ``` bash

--- a/fetch-validator-status/fetch_status.py
+++ b/fetch-validator-status/fetch_status.py
@@ -241,6 +241,7 @@ def list_networks():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fetch the status of all the indy-nodes within a given pool.")
     parser.add_argument("--net", choices=list_networks(), help="Connect to a known network using an ID.")
+    parser.add_argument("--list-nets", action="store_true", help="List known networks.")
     parser.add_argument("--genesis-url", default=os.environ.get('GENESIS_URL') , help="The url to the genesis file describing the ledger pool.  Can be specified using the 'GENESIS_URL' environment variable.")
     parser.add_argument("--genesis-path", default=os.getenv("GENESIS_PATH") or f"{get_script_dir()}/genesis.txn" , help="The path to the genesis file describing the ledger pool.  Can be specified using the 'GENESIS_PATH' environment variable.")
     parser.add_argument("-s", "--seed", default=os.environ.get('SEED') , help="The privileged DID seed to use for the ledger requests.  Can be specified using the 'SEED' environment variable.")
@@ -251,6 +252,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     verbose = args.verbose
+
+    if args.list_nets:
+        print(json.dumps(load_network_list(), indent=2))
+        exit()
 
     if args.net:
         log("Loading known network list ...")

--- a/fetch-validator-status/networks.json
+++ b/fetch-validator-status/networks.json
@@ -1,0 +1,38 @@
+{
+  "sbn": {
+    "name": "Sovrin BuilderNet",
+    "genesisUrl": "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_builder_genesis"
+  },
+  "ssn": {
+    "name": "Sovrin StagingNet",
+    "genesisUrl": "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
+  },
+  "smn": {
+    "name": "Sovrin MainNet",
+    "genesisUrl": "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis"
+  },
+  "vn": {
+    "name": "Local von-network",
+    "genesisUrl": "http://host.docker.internal:9000/genesis"
+  },
+  "bcd": {
+    "name": "BCovrin Dev",
+    "genesisUrl": "http://dev.bcovrin.vonx.io/genesis"
+  },
+  "bct": {
+    "name": "BCovrin Test ",
+    "genesisUrl": "http://test.bcovrin.vonx.io/genesis"
+  },
+  "bcp": {
+    "name": "BCovrin",
+    "genesisUrl": "http://prod.bcovrin.vonx.io/genesis"
+  },
+  "gld": {
+    "name": "GreenLight Dev Ledger ",
+    "genesisUrl": "http://dev.greenlight.bcovrin.vonx.io/genesis"
+  },
+  "gl": {
+    "name": "GreenLight Ledger ",
+    "genesisUrl": "http://greenlight.bcovrin.vonx.io/genesis"
+  }
+}


### PR DESCRIPTION
- Allows the use of short network Ids for known networks rather than a full genesis Url.
- Add `--net` command line argument and documentation.
- Add list of known networks.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>